### PR TITLE
Fix LongCat tool call parsing for tool_choice='auto'

### DIFF
--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -59,6 +59,7 @@ class FunctionCallParser:
 
         self.detector = detector
         self.tools = tools
+        self.tool_call_parser = tool_call_parser
 
     def has_tool_call(self, text: str) -> bool:
         """
@@ -179,12 +180,14 @@ class FunctionCallParser:
         ):
             strict_tag = self.get_structure_tag()
             return ("structural_tag", strict_tag)
-        elif tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+        elif (tool_choice == "required"
+              or isinstance(tool_choice, ToolChoice)
+              or (tool_choice == "auto" and self.tool_call_parser == "longcat")):
             ebnf = self.get_ebnf(tool_choice)
             return ("ebnf", ebnf) if ebnf is not None else None
 
     def get_ebnf(
-        self, tool_choice: Union[ToolChoice, Literal["required"]]
+        self, tool_choice: Union[ToolChoice, Literal["required", "auto"]]
     ) -> Optional[str]:
         """
         Get the EBNF grammar for the specified tool choice.


### PR DESCRIPTION
## Problem
LongCat models were not properly constrained for tool calls when `tool_choice='auto'` (default), only working with `tool_choice='required'`. This caused tool calls to be generated but not parsed correctly.

## Solution
Modified the constraint logic in `function_call_parser.py` to ensure LongCat models get EBNF constraints even for `tool_choice='auto'`, eliminating the need to manually set `tool_choice='required'`.

## Changes
- Added `self.tool_call_parser` instance variable to track parser type
- Modified `get_structure_constraint()` to include LongCat + 'auto' in EBNF eligibility
- Updated type annotations to accept 'auto' in `get_ebnf()` method

## Testing
The fix ensures LongCat models work correctly with default settings.