### PR TITLE
Tool (and response format schema) correctness fixes

### DIFF
--- a/python/sglang/srt/entrypoints/openai/json_schema_utils.py
+++ b/python/sglang/srt/entrypoints/openai/json_schema_utils.py
@@ -1,0 +1,44 @@
+import copy
+from typing import Any, Dict
+
+
+def _enforce_no_additional_properties(schema: Dict[str, Any]) -> None:
+    """Recursively disallow additional properties for object schemas."""
+    schema_type = schema.get("type")
+
+    if schema_type == "object":
+        schema.setdefault("additionalProperties", False)
+        properties = schema.get("properties", {})
+        if isinstance(properties, dict):
+            for subschema in properties.values():
+                if isinstance(subschema, dict):
+                    _enforce_no_additional_properties(subschema)
+    elif schema_type == "array":
+        items = schema.get("items")
+        if isinstance(items, dict):
+            _enforce_no_additional_properties(items)
+        elif isinstance(items, list):
+            for subschema in items:
+                if isinstance(subschema, dict):
+                    _enforce_no_additional_properties(subschema)
+
+    for composite_key in ("anyOf", "allOf", "oneOf"):
+        composite = schema.get(composite_key)
+        if isinstance(composite, list):
+            for subschema in composite:
+                if isinstance(subschema, dict):
+                    _enforce_no_additional_properties(subschema)
+
+    defs = schema.get("$defs") or schema.get("definitions")
+    if isinstance(defs, dict):
+        for subschema in defs.values():
+            if isinstance(subschema, dict):
+                _enforce_no_additional_properties(subschema)
+
+
+def normalize_json_schema(schema: Dict[str, Any], strict: bool) -> Dict[str, Any]:
+    """Return a normalized copy of the schema with stricter defaults when requested."""
+    normalized = copy.deepcopy(schema)
+    if strict:
+        _enforce_no_additional_properties(normalized)
+    return normalized

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -568,11 +568,7 @@ class ChatCompletionRequest(BaseModel):
                 if not isinstance(schema, dict):
                     return values
 
-            name_ = (
-                payload.get("name")
-                or schema.get("title")
-                or "Schema"
-            )
+            name_ = payload.get("name") or schema.get("title") or "Schema"
             strict_flag = payload.get("strict")
             if strict_flag is None:
                 strict_flag = True

--- a/python/sglang/srt/function_call/deepseekv31_detector.py
+++ b/python/sglang/srt/function_call/deepseekv31_detector.py
@@ -123,6 +123,18 @@ class DeepSeekV31Detector(BaseFormatDetector):
                 func_name = partial_match.group(1).strip()
                 func_args_raw = partial_match.group(2).strip()
 
+                if func_name not in self._tool_indices:
+                    logger.warning(
+                        "Model attempted to call undefined function: %s", func_name
+                    )
+                    self._buffer = ""
+                    self.current_tool_id = -1
+                    self.prev_tool_call_arr = []
+                    self.streamed_args_for_tool = []
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    return StreamingParseResult(normal_text="", calls=[])
+
                 # Initialize state if this is the first tool call
                 if self.current_tool_id == -1:
                     self.current_tool_id = 0

--- a/python/sglang/srt/function_call/deepseekv3_detector.py
+++ b/python/sglang/srt/function_call/deepseekv3_detector.py
@@ -121,6 +121,18 @@ class DeepSeekV3Detector(BaseFormatDetector):
                 func_name = partial_match.group(2).strip()
                 func_args_raw = partial_match.group(3).strip()
 
+                if func_name not in self._tool_indices:
+                    logger.warning(
+                        "Model attempted to call undefined function: %s", func_name
+                    )
+                    self._buffer = ""
+                    self.current_tool_id = -1
+                    self.prev_tool_call_arr = []
+                    self.streamed_args_for_tool = []
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    return StreamingParseResult(normal_text="", calls=[])
+
                 # Initialize state if this is the first tool call
                 if self.current_tool_id == -1:
                     self.current_tool_id = 0

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -177,13 +177,9 @@ class FunctionCallParser:
         """
         # NOTE: structural_tag only supports JSON-compatible content between the begin and end.
         # It cannot parse or validate function call Pythonic or XML-ish syntax.
-        if (
-            self.detector.supports_structural_tag()
-            and tool_choice == "auto"
-            and any(tool.function.strict for tool in self.tools)
-        ):
-            strict_tag = self.get_structure_tag()
-            return ("structural_tag", strict_tag)
+        if self.detector.supports_structural_tag() and tool_choice == "auto":
+            structural_tag = self.get_structure_tag()
+            return ("structural_tag", structural_tag)
         elif (
             tool_choice == "required"
             or isinstance(tool_choice, ToolChoice)

--- a/test/srt/test_function_call_parser.py
+++ b/test/srt/test_function_call_parser.py
@@ -8,6 +8,7 @@ from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import StreamingParseResult
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
 from sglang.srt.function_call.deepseekv31_detector import DeepSeekV31Detector
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.glm4_moe_detector import Glm4MoeDetector
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.function_call.kimik2_detector import KimiK2Detector
@@ -17,7 +18,6 @@ from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sglang.srt.function_call.qwen25_detector import Qwen25Detector
-from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
@@ -696,8 +696,11 @@ class TestEBNFGeneration(unittest.TestCase):
 
         # Check that the EBNF contains expected patterns
         self.assertIn("<longcat_tool_call>", ebnf)
-        self.assertIn('\\"name\\"" ":" "\\"get_weather\\"', ebnf)
-        self.assertIn('"\\"arguments\\"" ":"', ebnf)
+        self.assertIn(
+            'call_get_weather ::= "{" ws "\\"name\\"" ws ":" ws "\\"get_weather\\""',
+            ebnf,
+        )
+        self.assertIn('"\\"arguments\\"" ws ":" ws', ebnf)
 
         # Validate that the EBNF can be compiled by GrammarCompiler
         try:
@@ -1662,7 +1665,7 @@ class TestDeepSeekV31Detector(unittest.TestCase):
     def test_streaming_ignores_unknown_tool(self):
         """Ensure streaming parser ignores unknown tool names and can recover."""
         chunks = [
-            "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>img_gen<｜tool▁sep｜>{\"prompt\": \"test\"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+            '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>img_gen<｜tool▁sep｜>{"prompt": "test"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
         ]
 
         for chunk in chunks:
@@ -1674,7 +1677,7 @@ class TestDeepSeekV31Detector(unittest.TestCase):
         )
 
         follow_up = [
-            "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{\"city\": \"Osaka\"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+            '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"city": "Osaka"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
         ]
 
         seen = []


### PR DESCRIPTION
- Ignore calls to invalid/undefined tools
- Strict grammar when tool parser defines structural tag
- Prevent additional fields by default in output schemas
- Updated/additional tests, fix longcat test