### PR TITLE
Tool call in reasoning

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -242,18 +242,20 @@ def create_grammar_backend(
     else:
         raise ValueError(f"Invalid grammar backend: {name}")
 
-    if (
-        server_args.reasoning_parser
-        and hasattr(tokenizer, "think_end_id")
-        and tokenizer.think_end_id is not None
-    ):
+    think_end_ids = getattr(tokenizer, "reasoning_think_end_ids", None)
+    if think_end_ids is None:
+        single_end_id = getattr(tokenizer, "think_end_id", None)
+        if single_end_id is not None:
+            think_end_ids = [single_end_id]
+
+    if server_args.reasoning_parser and think_end_ids:
         from sglang.srt.constrained.reasoner_grammar_backend import (
             ReasonerGrammarBackend,
         )
 
         grammar_backend = ReasonerGrammarBackend(
             grammar_backend,
-            tokenizer.think_end_id,
+            think_end_ids,
             getattr(tokenizer, "reasoning_think_start_ids", None),
             getattr(tokenizer, "reasoning_initial_in_reasoning", True),
         )

--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -161,8 +161,14 @@ class ReasonerGrammarObject(BaseGrammarObject):
         return self.grammar.allocate_vocab_mask(vocab_size, batch_size, device)
 
     def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
-        if not self.is_in_reasoning:
-            self.grammar.fill_vocab_mask(vocab_mask, idx)
+        if self.is_in_reasoning:
+            row = vocab_mask[idx]
+            if row.dtype == torch.bool:
+                row.zero_()
+            else:
+                row.fill_(-1)
+            return
+        self.grammar.fill_vocab_mask(vocab_mask, idx)
 
     def move_vocab_mask(self, vocab_mask: torch.Tensor, device) -> torch.Tensor:
         return self.grammar.move_vocab_mask(vocab_mask, device)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -410,8 +410,11 @@ class Scheduler(
                     "reasoning-aware grammar will be disabled.",
                     reasoning_parser.detector.think_end_token,
                 )
+                self.tokenizer.reasoning_think_end_ids = None
                 self.tokenizer.think_end_id = None
             else:
+                self.tokenizer.reasoning_think_end_ids = think_end_ids
+                # Keep the legacy single-token attribute for backward compatibility.
                 self.tokenizer.think_end_id = think_end_ids[0]
 
             think_start_ids = self.tokenizer.encode(

--- a/python/sglang/srt/managers/template_manager.py
+++ b/python/sglang/srt/managers/template_manager.py
@@ -23,8 +23,9 @@ import logging
 import os
 import re
 import uuid
-import requests
 from typing import Optional
+
+import requests
 
 from sglang.srt.parser.code_completion_parser import (
     CompletionTemplate,
@@ -268,7 +269,6 @@ class TemplateManager:
                 override=True,
             )
         self._chat_template_name = template["name"]
-
 
     def _load_json_completion_template(self, template_path: str) -> None:
         """Load a JSON completion template file."""

--- a/test/srt/test_reasoner_grammar_backend.py
+++ b/test/srt/test_reasoner_grammar_backend.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from typing import List
 
+import torch
+
 from sglang.srt.constrained.base_grammar_backend import BaseGrammarObject
 from sglang.srt.constrained.reasoner_grammar_backend import ReasonerGrammarObject
 from sglang.srt.managers.scheduler import Scheduler
@@ -60,6 +62,49 @@ class TrackingGrammar(BaseGrammarObject):
         cloned = TrackingGrammar()
         cloned.recorded = list(self.recorded)
         return cloned
+
+    def try_jump_forward(self, tokenizer):
+        return None
+
+    def jump_forward_str_state(self, helper):
+        raise NotImplementedError
+
+    def jump_and_retokenize(self, old_output_ids, new_output_ids, next_state: int):
+        return None
+
+
+class MaskTrackingGrammar(BaseGrammarObject):
+    def __init__(self, bitset: bool):
+        super().__init__()
+        self.bitset = bitset
+        self.calls = 0
+
+    def accept_token(self, token: int):
+        return None
+
+    def allocate_vocab_mask(self, vocab_size: int, batch_size: int, device):
+        if self.bitset:
+            width = (vocab_size + 31) // 32
+            return torch.zeros(batch_size, width, dtype=torch.int32, device=device)
+        return torch.zeros(batch_size, vocab_size, dtype=torch.bool, device=device)
+
+    def fill_vocab_mask(self, vocab_mask, idx: int):
+        self.calls += 1
+        row = vocab_mask[idx]
+        if self.bitset:
+            row.fill_(0xAAAAAAAA)
+        else:
+            row.fill_(True)
+
+    def move_vocab_mask(self, vocab_mask, device):
+        return vocab_mask
+
+    @property
+    def apply_vocab_mask(self):
+        return lambda logits, mask: None
+
+    def copy(self) -> "MaskTrackingGrammar":
+        return MaskTrackingGrammar(self.bitset)
 
     def try_jump_forward(self, tokenizer):
         return None
@@ -151,3 +196,40 @@ def test_multitoken_think_end_sequence_transitions_cleanly():
     # Subsequent tokens must be validated by the downstream grammar again.
     grammar.accept_token(8)
     assert tracking.recorded == [3, 8]
+
+
+def test_fill_vocab_mask_allows_any_token_during_reasoning_bitset():
+    base = MaskTrackingGrammar(bitset=True)
+    grammar = ReasonerGrammarObject(
+        base, think_end_ids=None, think_start_ids=None, initial_in_reasoning=True
+    )
+    mask = base.allocate_vocab_mask(vocab_size=64, batch_size=2, device="cpu")
+
+    grammar.fill_vocab_mask(mask, 1)
+    assert torch.all(mask[1] == -1)
+    assert base.calls == 0
+
+    mask[1].zero_()
+    grammar.is_in_reasoning = False
+    grammar.fill_vocab_mask(mask, 1)
+    assert base.calls == 1
+    expected = torch.full_like(mask[1], 0xAAAAAAAA)
+    assert torch.equal(mask[1], expected)
+
+
+def test_fill_vocab_mask_allows_any_token_during_reasoning_bool():
+    base = MaskTrackingGrammar(bitset=False)
+    grammar = ReasonerGrammarObject(
+        base, think_end_ids=None, think_start_ids=None, initial_in_reasoning=True
+    )
+    mask = base.allocate_vocab_mask(vocab_size=8, batch_size=1, device="cpu")
+
+    grammar.fill_vocab_mask(mask, 0)
+    assert torch.all(mask[0] == 0)
+    assert base.calls == 0
+
+    mask[0].zero_()
+    grammar.is_in_reasoning = False
+    grammar.fill_vocab_mask(mask, 0)
+    assert base.calls == 1
+    assert torch.all(mask[0])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Some models, e.g. DeepSeek V3.1, will often emit tool calling tokens while inside a reasoning block (which then is followed by an EOS token), in which case there is no corresponding content block or function call inside a content block. Update the tool call parser to detect this case and parse the tool call from reasoning content.

## Modifications

When no tool call in content, check reasoning content.
(also misc. fixes related to bugs/failure modes in constrained outputs with MTP)

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
