### PR TITLE
Fix CLLMV verification for reasoning-only responses

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1023,8 +1023,11 @@ class OpenAIServingChat(OpenAIServingBase):
             metadata={"weight_version": ret[0]["meta_info"]["weight_version"]},
         )
         if choices:
+            verification_text = (
+                choices[0].message.content or choices[0].message.reasoning_content
+            )
             chunk.chutes_verification = get_chutes_verification_value(
-                chunk.id, chunk.created, choices[0].message.content
+                chunk.id, chunk.created, verification_text
             )
         return chunk
 


### PR DESCRIPTION
When models return reasoning-only responses (content=None, reasoning_content present), CLLMV verification can fail. This uses reasoning_content as the fallback content in the non-streaming response builder to keep verification stable.